### PR TITLE
Fix dynamicHelpers so that it would resolve the urls.

### DIFF
--- a/web.js
+++ b/web.js
@@ -29,16 +29,16 @@ app.dynamicHelpers({
     return req.headers['host'];
   },
   'scheme': function(req, res) {
-    req.headers['x-forwarded-proto'] || 'http'
+    return req.headers['x-forwarded-proto'] || 'http';
   },
   'url': function(req, res) {
     return function(path) {
-      return app.dynamicViewHelpers.scheme(req, res) + app.dynamicViewHelpers.url_no_scheme(path);
+      return app.dynamicViewHelpers.scheme(req, res) + app.dynamicViewHelpers.url_no_scheme(req, res)(path);
     }
   },
   'url_no_scheme': function(req, res) {
     return function(path) {
-      return '://' + app.dynamicViewHelpers.host(req, res) + path;
+      return '://' + app.dynamicViewHelpers.host(req, res) + (path || '');
     }
   },
 });


### PR DESCRIPTION
There was a couple of errors with the dynamic helpers.
1. scheme helper returns nothing, since there was no return statement for that helper.
2. when passing an undefined path, that needs to be caught otherwise 'undefined' will be appended to the path
3. cannot call dynamicHelper without req/res variable, doesn't work like that.

This will fix some issues where sharing the link, since those meta tags are needed to post the correct link to Facebook.
