### PR TITLE
Remove class on photo list items

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -195,7 +195,7 @@
         <h3>Recent photos</h3>
         <ul id="photos" class="photos">
           <% req.photos.forEach(function(photo) { %>
-            <li style="background-image: url(<%= photo.picture %>);" class="<%= photo.link %>">
+            <li style="background-image: url(<%= photo.picture %>);">
               <a href="<%= photo.link %>" target="_top"></a>
             </li>
           <% }); %>


### PR DESCRIPTION
Classes for each photo that are equivalent to the photo URL aren't even valid.
