### PR TITLE
Use app_id on plate object instead of reading from Facebook

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -23,7 +23,7 @@
     <meta property="og:image" content="<%= url('/logo.png') %>" />
     <meta property="og:site_name" content="<%= app.name %>" />
     <meta property="og:description" content="My first app" />
-    <meta property="fb:app_id" content="<%= app.id %>" />
+    <meta property="fb:app_id" content="<%= req.facebook.plate.app_id %>" />
 
     <script type="text/javascript" src="/scripts/jquery.min.js"></script>
 
@@ -96,7 +96,7 @@
     <script type="text/javascript">
       window.fbAsyncInit = function() {
         FB.init({
-          appId      : '<%= app.id %>', // App ID
+          appId      : '<%= req.facebook.plate.app_id %>', // App ID
           channelUrl : '<%= url_no_scheme('/channel.html') %>', // Channel File
           status     : true, // check login status
           cookie     : true, // enable cookies to allow the server to access the session


### PR DESCRIPTION
Fixes cases where the app_id is required but not accessible from the API due to the app being hidden from non-logged-in developers (#11).

This doesn't fix other problems stemming from the app information being unreachable (ie. the title of the app). heroku/faceplate#19 potentially may be a fix for those cases. However, the app_id should still be taken from the local configuration and not the remote query.

heroku/faceplate#20 would make this fix even cleaner.
